### PR TITLE
feat(payload): Add default db entry and PUT to /api/v2/payload/

### DIFF
--- a/main.go
+++ b/main.go
@@ -59,7 +59,9 @@ func main() {
 		s3Host,
 		ipxeTemplateFile,
 		ipxeDefaultImage,
-		ipxeDefaultBucket string
+		ipxeDefaultBucket,
+    payloadsDefaultPayloadId,
+    payloadsDefaultPayloadDirectory string
 	)
 
 	flag.StringVar(&httpAddr, "http", "localhost:8080", "HTTP service address to listen for incoming requests on")
@@ -67,6 +69,8 @@ func main() {
 	flag.StringVar(&ipxeTemplateFile, "ipxe.template", "pkg/ipxe/templates/template_https.ipxe", "Relative path to ipxe template file")
 	flag.StringVar(&ipxeDefaultImage, "ipxe.default.image", "ncore-1.24.0-nodisplay", "Default image used when database is unavailable or no entry found for macAddress")
 	flag.StringVar(&ipxeDefaultBucket, "ipxe.default.bucket", "coreweave-ncore-images", "Default image used when database is unavailable or no entry found for macAddress")
+	flag.StringVar(&payloadsDefaultPayloadId, "payloads.default.payloadId", "default", "Default PayloadId assigned when no entry found for macAddress")
+	flag.StringVar(&payloadsDefaultPayloadDirectory, "payloads.default.payloadDirectory", "kube-worker", "Default PayloadDirectory assigned when no entry found for macAddress")
 
 	flag.Parse()
 	pgxLogLevel, err := database.LogLevelFromEnv()
@@ -96,7 +100,10 @@ func main() {
 		Payloads: payloads.NewService(
 			&postgres.DB{
 				Postgres: pgPoolPayloads,
-			}),
+			},
+      payloadsDefaultPayloadId,
+      payloadsDefaultPayloadDirectory,
+    ),
 		Ipxe: ipxe.NewService(
 			&postgres.DB{
 				Postgres: pgPoolIpxe,

--- a/pkg/api/http.go
+++ b/pkg/api/http.go
@@ -12,11 +12,11 @@ import (
 	"github.com/coreweave/ncore-api/pkg/payloads"
 )
 
-type ipxeErrors struct {
+type jsonErrors struct {
   Errors []string
 }
 
-func (e *ipxeErrors) writeErrors(w http.ResponseWriter) {
+func (e *jsonErrors) writeErrors(w http.ResponseWriter) {
   w.Header().Set("Content-Type", "application/json")
   enc := json.NewEncoder(w)
   enc.SetIndent("", "\t")
@@ -33,7 +33,7 @@ func NewHTTPServer(i *ipxe.Service, p *payloads.Service) http.Handler {
 		mux:      http.NewServeMux(),
 	}
 	// /payload/<macAddress> returns the PayloadId and PayloadDirectory as a json object
-	s.mux.HandleFunc("/api/v2/payload/", s.handleGetNodePayload)
+	s.mux.HandleFunc("/api/v2/payload/", s.handleNodePayload)
 	// /payload/config/<payloadId> returns the payload parameters as a json object
 	s.mux.HandleFunc("/api/v2/payload/config/", s.handleGetPayloadParameters)
 	// /ipxe/config/<macAddress> returns the IpxeConfig as a json object
@@ -54,39 +54,117 @@ type HTTPServer struct {
 	mux      *http.ServeMux
 }
 
-func (s *HTTPServer) handleGetNodePayload(w http.ResponseWriter, r *http.Request) {
-	macAddress := r.URL.Path[len("/api/v2/payload/"):]
-	if macAddress == "" || strings.ContainsRune(macAddress, '/') {
-		http.NotFound(w, r)
+func (s *HTTPServer) handleNodePayload(w http.ResponseWriter, r *http.Request) {
+  if r.Method != "GET" && r.Method != "PUT" && r.Method != "DELETE" {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		w.Write([]byte("405 - Method not allowed. Only GET, PUT, and DELETE allowed"))
+		return
+	}
+	if (r.Method == "PUT" || r.Method == "DELETE") && r.Header.Get("Content-type") != "application/json" {
+		w.WriteHeader(http.StatusUnsupportedMediaType)
+		w.Write([]byte("415 - Unsupported Media Type. Only application/json content-type allowed"))
 		return
 	}
 
-  macAddress = strings.Replace(strings.ToLower(macAddress), ":", "", -1)
+  switch {
+	case r.Method == "GET":
+    macAddress := r.URL.Path[len("/api/v2/payload/"):]
+    if macAddress == "" || strings.ContainsRune(macAddress, '/') {
+      http.NotFound(w, r)
+      return
+    }
 
-  // if query includes a hostname instead of full macAddress
-  if len(macAddress) == 7 {
-    macAddress = "%" + macAddress[1:]
-  }
+    macAddress = strings.Replace(strings.ToLower(macAddress), ":", "", -1)
 
-	payload, err := s.payloads.GetNodePayload(r.Context(), macAddress)
-	switch {
-	case err == context.Canceled, err == context.DeadlineExceeded:
-		// TODO: Add warning log
-		return
-	case err != nil:
-		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
-		log.Println(err)
-	case payload == nil:
-		// TODO: Return a default payload object
-		http.Error(w, fmt.Sprintf("payload not found for macAddress: %s", macAddress), http.StatusNotFound)
-	default:
+    // if query includes a hostname instead of full macAddress
+    if len(macAddress) == 7 {
+      macAddress = "%" + macAddress[1:]
+    }
+
+    payload, err := s.payloads.GetNodePayload(r.Context(), macAddress)
+    switch {
+    case err == context.Canceled, err == context.DeadlineExceeded:
+      // TODO: Add warning log
+      return
+    case err != nil:
+      http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+      log.Println(err)
+    case payload == nil:
+      if len(macAddress) == 7 {
+        http.Error(w, fmt.Sprintf("payload not found for hostname: %s", macAddress), http.StatusNotFound)
+      } else {
+        log.Printf("Adding default payload entry for macAddress: %s", macAddress)
+        payload, err := s.payloads.AddDefaultNodePayload(r.Context(), macAddress)
+        var errors []string
+        if err != nil {
+          errorsJson := &jsonErrors{
+            Errors: append(errors, err.Error()),
+          }
+          errorsJson.writeErrors(w)
+          return
+        }
+        w.Header().Set("Content-Type", "application/json")
+        enc := json.NewEncoder(w)
+        enc.SetIndent("", "\t")
+        if err := enc.Encode(payload); err != nil {
+          log.Printf("cannot json encode payload request: %v", err)
+        }
+      }
+    default:
+      w.Header().Set("Content-Type", "application/json")
+      enc := json.NewEncoder(w)
+      enc.SetIndent("", "\t")
+      if err := enc.Encode(payload); err != nil {
+        log.Printf("cannot json encode payload request: %v", err)
+      }
+    }
+	case r.Method == "PUT":
+		defer r.Body.Close()
+		var npd *payloads.NodePayloadDb
+		var errors []string
+		dec := json.NewDecoder(r.Body)
+		if err := dec.Decode(&npd); err != nil {
+			errors = append(errors, fmt.Sprintf(`cannot json decode NodePayload request: %v`, err))
+		} else {
+      if npd.PayloadId == "" {
+        errors = append(errors, "PayloadId is missing.")
+      }
+      if npd.MacAddress == "" {
+        errors = append(errors, "MacAddress is missing.")
+      }
+    }
+		if len(errors) > 0 {
+      errorsJson := &jsonErrors{
+        Errors: errors,
+      }
+      errorsJson.writeErrors(w)
+      return
+		}
+
+    npd.MacAddress = strings.Replace(strings.ToLower(npd.MacAddress), ":", "", -1)
+
+    // if query includes a hostname instead of full macAddress
+    if len(npd.MacAddress) == 7 {
+      npd.MacAddress = "%" + npd.MacAddress[1:]
+    }
+
+    config, err := s.payloads.UpdateNodePayload(r.Context(), npd)
+		if err != nil {
+      errors = append(errors, err.Error())
+      errorsJson := &jsonErrors{
+        Errors: errors,
+      }
+      errorsJson.writeErrors(w)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
 		w.Header().Set("Content-Type", "application/json")
 		enc := json.NewEncoder(w)
 		enc.SetIndent("", "\t")
-		if err := enc.Encode(payload); err != nil {
-			log.Printf("cannot json encode payload request: %v", err)
+		if err := enc.Encode(config); err != nil {
+			log.Printf("cannot json encode payload response: %v", err)
 		}
-	}
+  }
 }
 
 func (s *HTTPServer) handleGetPayloadParameters(w http.ResponseWriter, r *http.Request) {
@@ -207,7 +285,7 @@ func (s *HTTPServer) handleIpxeImages(w http.ResponseWriter, r *http.Request) {
       }
     }
 		if len(errors) > 0 {
-      errorsJson := &ipxeErrors{
+      errorsJson := &jsonErrors{
         Errors: errors,
       }
       errorsJson.writeErrors(w)
@@ -216,7 +294,7 @@ func (s *HTTPServer) handleIpxeImages(w http.ResponseWriter, r *http.Request) {
 		config, err := s.ipxe.CreateIpxeImage(r.Context(), ic)
 		if err != nil {
       errors = append(errors, err.Error())
-      errorsJson := &ipxeErrors{
+      errorsJson := &jsonErrors{
         Errors: errors,
       }
       errorsJson.writeErrors(w)

--- a/pkg/api/http.go
+++ b/pkg/api/http.go
@@ -91,6 +91,16 @@ func (s *HTTPServer) handleNodePayload(w http.ResponseWriter, r *http.Request) {
       macAddress = "%" + macAddress[1:]
     }
 
+    if len(macAddress) != 12 && len(macAddress) != 7 {
+      var errors []string
+      errors = append(errors, "Invalid mac_address")
+      errorsJson := &jsonErrors{
+        Errors: errors,
+      }
+      errorsJson.writeErrors(w)
+			return
+    }
+
     payload, err := s.payloads.GetNodePayload(r.Context(), macAddress)
     switch {
     case err == context.Canceled, err == context.DeadlineExceeded:
@@ -157,6 +167,17 @@ func (s *HTTPServer) handleNodePayload(w http.ResponseWriter, r *http.Request) {
     if len(npd.MacAddress) == 7 {
       npd.MacAddress = "%" + npd.MacAddress[1:]
     }
+
+    if len(npd.MacAddress) != 12 && len(npd.MacAddress) != 7 {
+      var errors []string
+      errors = append(errors, "Invalid mac_address")
+      errorsJson := &jsonErrors{
+        Errors: errors,
+      }
+      errorsJson.writeErrors(w)
+			return
+    }
+
     payloads := s.payloads.GetAvailablePayloads(r.Context())
 
     if ! contains(payloads, npd.PayloadId) {

--- a/pkg/payloads/payloads.go
+++ b/pkg/payloads/payloads.go
@@ -5,10 +5,16 @@ import (
 	"time"
 )
 
-// NodePayload for mac_address.
+// NodePayload with directory for mac_address.
 type NodePayload struct {
 	PayloadId        string
 	PayloadDirectory string
+	MacAddress       string
+}
+
+// NodePayload payloads.node_payloads entry for mac_address.
+type NodePayloadDb struct {
+	PayloadId        string
 	MacAddress       string
 }
 
@@ -48,6 +54,23 @@ func (s *Service) GetNodePayload(ctx context.Context, macAddress string) (*NodeP
 		return nil, ValidationError{"missing payload macAddress"}
 	}
 	return s.db.GetNodePayload(ctx, macAddress)
+}
+
+// AddDefaultNodePayload adds a db entry with defaults for mac_address.
+func (s *Service) AddDefaultNodePayload(ctx context.Context, macAddress string) (*NodePayloadDb, error) {
+	if macAddress == "" {
+		return nil, ValidationError{"missing payload macAddress"}
+	}
+	var npd = &NodePayloadDb{
+		PayloadId: s.payloadsDefaultPayloadId,
+		MacAddress: macAddress,
+	}
+	return s.db.AddDefaultNodePayload(ctx, npd)
+}
+
+// UpdateNodePayload updates the PayloadId for mac_address.
+func (s *Service) UpdateNodePayload(ctx context.Context, config *NodePayloadDb) (*NodePayloadDb, error) {
+	return s.db.UpdateNodePayload(ctx, config)
 }
 
 // GetPayloadParameters returns a PayloadSchema for PayloadId.

--- a/pkg/payloads/payloads.go
+++ b/pkg/payloads/payloads.go
@@ -68,6 +68,11 @@ func (s *Service) AddDefaultNodePayload(ctx context.Context, macAddress string) 
 	return s.db.AddDefaultNodePayload(ctx, npd)
 }
 
+// GetAvailablePayloads returns a list of available payloads
+func (s *Service) GetAvailablePayloads(ctx context.Context) ([]string) {
+  return s.db.GetAvailablePayloads(ctx)
+}
+
 // UpdateNodePayload updates the PayloadId for mac_address.
 func (s *Service) UpdateNodePayload(ctx context.Context, config *NodePayloadDb) (*NodePayloadDb, error) {
 	return s.db.UpdateNodePayload(ctx, config)

--- a/pkg/payloads/service.go
+++ b/pkg/payloads/service.go
@@ -33,6 +33,9 @@ type DB interface {
 	// GetPayload returns a payload for a node.
 	GetNodePayload(ctx context.Context, macAddress string) (*NodePayload, error)
 
+  // GetAvailablePayloads returns a list of available payloads
+  GetAvailablePayloads(ctx context.Context) ([]string)
+
   // AddDefaultNodePayload adds a db entry with defaults for mac_address.
   AddDefaultNodePayload(ctx context.Context, config *NodePayloadDb) (*NodePayloadDb, error)
 

--- a/pkg/payloads/service.go
+++ b/pkg/payloads/service.go
@@ -6,14 +6,24 @@ import (
 )
 
 // NewService creates an API service.
-func NewService(db DB) *Service {
+func NewService(
+    db DB,
+    payloadsDefaultPayloadId string,
+    payloadsDefaultPayloadDirectory string,
+) *Service {
 	log.Printf("Starting Payloads service")
-	return &Service{db: db}
+	return &Service{
+    db: db,
+    payloadsDefaultPayloadId: payloadsDefaultPayloadId,
+    payloadsDefaultPayloadDirectory: payloadsDefaultPayloadDirectory,
+  }
 }
 
 // Service for the API.
 type Service struct {
 	db DB
+  payloadsDefaultPayloadId string
+  payloadsDefaultPayloadDirectory string
 }
 
 // DB layer.
@@ -22,6 +32,12 @@ type Service struct {
 type DB interface {
 	// GetPayload returns a payload for a node.
 	GetNodePayload(ctx context.Context, macAddress string) (*NodePayload, error)
+
+  // AddDefaultNodePayload adds a db entry with defaults for mac_address.
+  AddDefaultNodePayload(ctx context.Context, config *NodePayloadDb) (*NodePayloadDb, error)
+
+  // UpdateNodePayload updates the PayloadId for mac_address.
+  UpdateNodePayload(ctx context.Context, config *NodePayloadDb) (*NodePayloadDb, error)
 
 	// GetPayload returns a payload for a node.
 	GetPayloadParameters(ctx context.Context, payloadId string) (interface{}, error)


### PR DESCRIPTION
Creates a new db entry with defaults in payloads.node_payloads for mac_address if GET `/api/v2/payload/<macAddress>` is passed a full macAddress that doesn't have an existing entry.
Otherwise, returns the NodePayload.

Adds PUT to `/api/v2/payload/` that accepts a NodePayload to update the PayloadId
ex.
```
# full macAddress
curl -XPUT localhost:8080/api/v2/payload/ -H 'Content-Type: application/json' -d '{"PayloadId": "new-payload-id", "MacAddress": "0123456789ab"}'

# or 7-letter hostname
curl -XPUT localhost:8080/api/v2/payload/ -H 'Content-Type: application/json' -d '{"PayloadId": "new-payload-id", "MacAddress": "56789ab"}'  

