### PR TITLE
Add subnet default payload logic

### DIFF
--- a/migrations/payloads/002_add_subnet_default_payloads.sql
+++ b/migrations/payloads/002_add_subnet_default_payloads.sql
@@ -1,0 +1,11 @@
+CREATE TABLE subnet_default_payloads (
+    subnet cidr NOT NULL PRIMARY KEY,
+    payload_id text NOT NULL CHECK (payload_id != ''),
+    created_at timestamp with time zone NOT NULL DEFAULT now(),
+    modified_at timestamp with time zone NOT NULL DEFAULT now()
+    -- TODO: add subnet_default_payloads table to keep track of each change here.
+);
+
+---- create above / drop below ----
+
+DROP TABLE subnet_default_payloads;

--- a/pkg/payloads/payloads.go
+++ b/pkg/payloads/payloads.go
@@ -22,8 +22,6 @@ type NodePayloadDb struct {
 type Payload struct {
 	PayloadId        string
 	PayloadDirectory string
-	CreatedAt        time.Time
-	ModifiedAt       time.Time
 }
 
 // PayloadSchema for payload_id.
@@ -54,6 +52,16 @@ func (s *Service) GetNodePayload(ctx context.Context, macAddress string) (*NodeP
 		return nil, ValidationError{"missing payload macAddress"}
 	}
 	return s.db.GetNodePayload(ctx, macAddress)
+}
+
+// GetSubnetDefaultPayload accepts an ip address string and checks if payloads.subnet_default_payloads table
+// contains a payload_id for the corresponding cidr
+// Returns a Payload
+func (s *Service) GetSubnetDefaultPayload(ctx context.Context, ipAddress string) (*Payload, error) {
+	if ipAddress == "" {
+		return nil, ValidationError{"missing payload ipAddress"}
+	}
+	return s.db.GetSubnetDefaultPayload(ctx, ipAddress)
 }
 
 // AddDefaultNodePayload adds a db entry with defaults for mac_address.

--- a/pkg/payloads/service.go
+++ b/pkg/payloads/service.go
@@ -33,6 +33,11 @@ type DB interface {
 	// GetPayload returns a payload for a node.
 	GetNodePayload(ctx context.Context, macAddress string) (*NodePayload, error)
 
+	// GetSubnetDefaultPayload accepts an ip address string and checks if payloads.subnet_default_payloads table
+	// contains a payload_id for the corresponding cidr
+	// Returns a Payload
+	GetSubnetDefaultPayload(ctx context.Context, ipAddress string) (*Payload, error)
+
 	// GetAvailablePayloads returns a list of available payloads
 	GetAvailablePayloads(ctx context.Context) []string
 


### PR DESCRIPTION
Note: opting not to maintain a payload.node_payload entry for "subnet-default" for the sake of reduced complexity.

TODO: Implement alerts for both subnet default and flag default payloads instead of database entries.