### PR TITLE
feat(payloads): Add defaulted entries for subnet and flag

### DIFF
--- a/pkg/payloads/payloads.go
+++ b/pkg/payloads/payloads.go
@@ -64,17 +64,26 @@ func (s *Service) GetSubnetDefaultPayload(ctx context.Context, ipAddress string)
 	return s.db.GetSubnetDefaultPayload(ctx, ipAddress)
 }
 
-// AddDefaultNodePayload adds a db entry with defaults for mac_address.
-func (s *Service) AddDefaultNodePayload(ctx context.Context, macAddress string) (*NodePayload, error) {
-	if macAddress == "" {
-		return nil, ValidationError{"missing payload macAddress"}
+// AddNodePayload adds a NodePayload entry.
+// Returns a NodePayload
+func (s *Service) AddNodePayload(ctx context.Context, nodePayloadDb *NodePayloadDb) error {
+	if nodePayloadDb.PayloadId == "" {
+		return ValidationError{"missing nodePayloadDb PayloadId"}
 	}
-	var np = &NodePayload{
+	if nodePayloadDb.MacAddress == "" {
+		return ValidationError{"missing nodePayloadDb payload MacAddress"}
+	}
+
+	return s.db.AddNodePayload(ctx, nodePayloadDb)
+}
+
+// GetDefaultPayload returns the default Payload from flags.
+func (s *Service) GetDefaultPayload(ctx context.Context) *Payload {
+	var p = &Payload{
 		PayloadId:        s.payloadsDefaultPayloadId,
 		PayloadDirectory: s.payloadsDefaultPayloadDirectory,
-		MacAddress:       macAddress,
 	}
-	return s.db.AddDefaultNodePayload(ctx, np)
+	return p
 }
 
 // GetAvailablePayloads returns a list of available payloads

--- a/pkg/payloads/service.go
+++ b/pkg/payloads/service.go
@@ -41,8 +41,8 @@ type DB interface {
 	// GetAvailablePayloads returns a list of available payloads
 	GetAvailablePayloads(ctx context.Context) []string
 
-	// AddDefaultNodePayload adds a db entry with defaults for mac_address.
-	AddDefaultNodePayload(ctx context.Context, config *NodePayload) (*NodePayload, error)
+	// AddNodePayload adds a NodePayloadDb entry for mac_address
+	AddNodePayload(ctx context.Context, config *NodePayloadDb) error
 
 	// UpdateNodePayload updates the PayloadId for mac_address.
 	UpdateNodePayload(ctx context.Context, config *NodePayloadDb) (*NodePayloadDb, error)


### PR DESCRIPTION
Adds the corresponding subnet default PayloadId for mac address in payloads.node_payloads if valid entry found in subnet_default_payloads.

Note: the payloads in payloads.subnet_default_payloads must exist in payloads.payloads or else the "default" entry will be added for the nodes based on the api flags.
Valid (aka not missing from payloads) PayloadIds in payloads.subnet_default_payloads will take precedence over the "default" PayloadId, but not over other valid PayloadIds


Ex. (bad payload entry in subnet_default_payloads)
- Requester mac: 0123456789ab ip: 127.0.0.1
- subnet_default_payloads: {127.0.0.0/24 kube-worker-invalid}
- payloads: empty
- node_payloads: empty
- api flags: 
  payloadsDefaultPayloadId: "default"
  payloadsDefaultPayloadDirectory: "kube-worker"
```
curl localhost:8080/api/v2/payload/0123456789ab 
{                                                                                                                               
        "PayloadId": "default",                                                                                                 
        "PayloadDirectory": "kube-worker",                                                                                      
        "MacAddress": "0123456789ab"                                                                                            
}
# payloads.node_payloads db entry created with "default" PayloadId
```

Ex. (good payload entry in subnet_default_payloads)
- Requester mac: 0123456789ab ip: 127.0.0.1
- subnet_default_payloads: {127.0.0.0/24 kube-worker-valid}
- payloads: {kube-worker-valid kube-worker-directory kube-worker-schema}
- node_payloads: empty
- api flags: 
  payloadsDefaultPayloadId: "default"
  payloadsDefaultPayloadDirectory: "kube-worker"
```
curl localhost:8080/api/v2/payload/0123456789ab 
{                                                                                                                               
        "PayloadId": "kube-worker-valid",                                                                                                 
        "PayloadDirectory": "kube-worker-directory",                                                                                      
        "MacAddress": "0123456789ab"                                                                                            
}
# payloads.node_payloads db entry created with "kube-worker-valid" PayloadId
```

Ex. (good payload entry in subnet_default_payloads, but node already has non-default entry)
- Requester mac: 0123456789ab ip: 127.0.0.1
- subnet_default_payloads: {127.0.0.0/24 kube-worker-valid}
- payloads: {kube-worker-valid kube-worker-directory kube-worker-schema}
  {other-valid-payload other-directory other-schema}
- node_payloads: {0123456789ab  other-valid-payload}
- api flags: 
  payloadsDefaultPayloadId: "default"
  payloadsDefaultPayloadDirectory: "kube-worker"
```
curl localhost:8080/api/v2/payload/0123456789ab 
{                                                                                                                               
        "PayloadId": "other-valid-payload",                                                                                                 
        "PayloadDirectory": "other-directory",                                                                                      
        "MacAddress": "0123456789ab"                                                                                            
}
# no new entries created in payloads.node_payloads
```