### PR TITLE
feat(ipxe): Add subnet default image entries for nodes

### DIFF
--- a/migrations/ipxe/002_add_subnet_default_images.sql
+++ b/migrations/ipxe/002_add_subnet_default_images.sql
@@ -1,0 +1,12 @@
+CREATE TABLE subnet_default_images (
+    subnet cidr NOT NULL PRIMARY KEY,
+    image_tag text NOT NULL CHECK (image_tag != ''),
+    image_type text NOT NULL CHECK (image_type != ''),
+    created_at timestamp with time zone NOT NULL DEFAULT now(),
+    modified_at timestamp with time zone NOT NULL DEFAULT now()
+    -- TODO: add subnet_default_images table to keep track of each change here.
+);
+
+---- create above / drop below ----
+
+DROP TABLE subnet_default_images;

--- a/pkg/ipxe/service.go
+++ b/pkg/ipxe/service.go
@@ -49,7 +49,8 @@ type Service struct {
 type DB interface {
 	// GetIpxe returns an IpxeConfig for a macAddress.
 	GetIpxeDbConfig(ctx context.Context, macAddress string) (*IpxeDbConfig, error)
-	CreateNodeIpxeConfig(ctx context.Context, config *IpxeNodeDbConfig) (*IpxeNodeDbConfig, error)
+	GetSubnetDefaultIpxeDbConfig(ctx context.Context, ipAddress string) (*IpxeDbConfig, error)
+	CreateNodeIpxeConfig(ctx context.Context, config *IpxeNodeDbConfig) error
 	CreateIpxeImage(ctx context.Context, config *IpxeDbConfig) (*IpxeConfig, error)
 	DeleteIpxeImage(ctx context.Context, config *IpxeDbDeleteConfig) (*IpxeDbConfig, error)
 }

--- a/pkg/ipxe/template.go
+++ b/pkg/ipxe/template.go
@@ -6,7 +6,7 @@ import (
 	"text/template"
 )
 
-func GetIpxeConfigTemplate(ipxeTemplateFile string) template.Template {
+func getIpxeConfigTemplate(ipxeTemplateFile string) template.Template {
 	t, err := template.New(filepath.Base(ipxeTemplateFile)).ParseFiles(ipxeTemplateFile)
 	if err != nil {
 		log.Printf("GetIpxeConfigTemplate error parsing template: %v", err)


### PR DESCRIPTION
Subnet default entry will always take priority for a node, but it won't overwrite existing db entries if nodes had a "default" or other image assigned already.

If no entry exists it will add the entry for the subnet default image to the node (rather than "default" - which is what api default assigns)


TODO: Add an update to the sql for assigning the subnet default image to the node entry

