### PR TITLE
Update: Node_payload updates for create and delete operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,16 +68,51 @@ go run .
 ### Endpoints
 
 - `/api/v2/payload/<macAddress>`
-  - returns the PayloadId and PayloadDirectory as a json object for the given macAddress
-  - used by [payloads.service](https://github.com/coreweave/ncore-image-tenant/blob/ca696c84cc2d3deb99d3cb61336062d22425a9da/ansible/roles/base/files/systemd/scripts/payloads.sh) in the ncore-image
-  - ex. `curl localhost:8080/api/v2/payload/test_mac`
+  - GET:
+    - returns the first NodePayload as a json object for the given macAddress
+    - used by [payloads.service](https://github.com/coreweave/ncore-image-tenant/blob/ca696c84cc2d3deb99d3cb61336062d22425a9da/ansible/roles/base/files/systemd/scripts/payloads.sh) in the ncore-image
+    - ex. `curl +XGET localhost:8080/api/v2/payload/test_mac`
 
-      ```json
-      {
-              "PayloadId": "kube-worker",
-              "PayloadDirectory": "kube-worker",
-              "MacAddress": "test_mac"
-      }
+        ```json
+        {
+                "PayloadId": "kube-worker",
+                "PayloadDirectory": "kube-worker",
+                "MacAddress": "test_mac"
+        }
+        ```
+
+- `/api/v2/payload/<macAddress>/<payloadId>`
+  - PUT:
+    - inserts/updates the node entry within node_payloads table
+    - returns a list of NodePayload objects assigned as a json list for the given macAddress
+    - used by [kubernetes-node.join](https://github.com/coreweave/kubernetes-node/blob/5f0ea40f0d8eb75931dfefb550c8ddf756bbb238/join.sh), [kubernetes-node.enable_virtualization](https://github.com/coreweave/kubernetes-node/blob/5f0ea40f0d8eb75931dfefb550c8ddf756bbb238/enable_virtualization.sh), [kubernetes-node.disable_virtualization](https://github.com/coreweave/kubernetes-node/blob/5f0ea40f0d8eb75931dfefb550c8ddf756bbb238/disable_virtualization.sh), and [kubernetes-node.set_nvlink](https://github.com/coreweave/kubernetes-node/blob/5f0ea40f0d8eb75931dfefb550c8ddf756bbb238/set_nvlink.sh)
+    - ex: `curl +XPUT localhost:8080/api/v2/payload/test_mac/test_payload`
+
+        ```json
+        [
+          {
+                "PayloadId": "test_payload",
+                "PayloadDirectory": "kube-worker",
+                "MacAddress": "test_mac"
+          }
+        ]
+        ```
+
+  - DELETE
+    - deletes the node entry within node_payloads table
+    - returns a list of NodePayload objects assigned as a json list for the given macAddress
+    - used by [kubernetes-node.leave](https://github.com/coreweave/kubernetes-node/blob/5f0ea40f0d8eb75931dfefb550c8ddf756bbb238/leave.sh)
+    - ex: `curl +XDELETE localhost:8080/api/v2/payload/test_mac/test_payload`
+
+        ```json
+        [
+          {
+                "PayloadId": "not_test_payload",
+                "PayloadDirectory": "kube-worker",
+                "MacAddress": "test_mac"
+          }
+        ]
+        ```
 
 - `/api/v2/payload/config/<payloadId>`
   - returns the payload parameters as a json object for a given payloadId

--- a/pkg/payloads/payloads.go
+++ b/pkg/payloads/payloads.go
@@ -46,12 +46,13 @@ type PayloadParameters struct {
 	ModifiedAt time.Time
 }
 
-// GetNodePayload returns a NodePayload for mac_address.
-func (s *Service) GetNodePayload(ctx context.Context, macAddress string) (*NodePayload, error) {
+// GetNodePayloads reads all payloads for mac_address and returns them as a list.
+// Returns a list of Payloads
+func (s *Service) GetNodePayloads(ctx context.Context, macAddress string) ([]*NodePayload, error) {
 	if macAddress == "" {
 		return nil, ValidationError{"missing payload macAddress"}
 	}
-	return s.db.GetNodePayload(ctx, macAddress)
+	return s.db.GetNodePayloads(ctx, macAddress)
 }
 
 // GetSubnetDefaultPayload accepts an ip address string and checks if payloads.subnet_default_payloads table
@@ -65,13 +66,13 @@ func (s *Service) GetSubnetDefaultPayload(ctx context.Context, ipAddress string)
 }
 
 // AddNodePayload adds a NodePayload entry.
-// Returns a NodePayload
-func (s *Service) AddNodePayload(ctx context.Context, nodePayloadDb *NodePayloadDb) error {
+// Returns a list of Payloads
+func (s *Service) AddNodePayload(ctx context.Context, nodePayloadDb *NodePayloadDb) ([]*NodePayload, error) {
 	if nodePayloadDb.PayloadId == "" {
-		return ValidationError{"missing nodePayloadDb PayloadId"}
+		return nil, ValidationError{"missing nodePayloadDb PayloadId"}
 	}
 	if nodePayloadDb.MacAddress == "" {
-		return ValidationError{"missing nodePayloadDb payload MacAddress"}
+		return nil, ValidationError{"missing nodePayloadDb payload MacAddress"}
 	}
 
 	return s.db.AddNodePayload(ctx, nodePayloadDb)
@@ -92,8 +93,15 @@ func (s *Service) GetAvailablePayloads(ctx context.Context) []string {
 }
 
 // UpdateNodePayload updates the PayloadId for mac_address.
-func (s *Service) UpdateNodePayload(ctx context.Context, config *NodePayloadDb) (*NodePayloadDb, error) {
+// Returns a list of Payloads
+func (s *Service) UpdateNodePayload(ctx context.Context, config *NodePayloadDb) ([]*NodePayload, error) {
 	return s.db.UpdateNodePayload(ctx, config)
+}
+
+// DeleteNodePayload deletes a NodePayload for mac_address/payload tuple.
+// Returns a list of Payloads
+func (s *Service) DeleteNodePayload(ctx context.Context, config *NodePayloadDb) ([]*NodePayload, error) {
+	return s.db.DeleteNodePayload(ctx, config)
 }
 
 // GetPayloadParameters returns a PayloadSchema for PayloadId.

--- a/pkg/payloads/service.go
+++ b/pkg/payloads/service.go
@@ -30,8 +30,8 @@ type Service struct {
 //
 //go:generate mockgen --build_flags=--mod=mod -package payloads -destination mock_payloads_db_test.go . DB
 type DB interface {
-	// GetPayload returns a payload for a node.
-	GetNodePayload(ctx context.Context, macAddress string) (*NodePayload, error)
+	// GetNodePayloads reads all payloads for mac_address and returns them as a list.
+	GetNodePayloads(ctx context.Context, macAddress string) ([]*NodePayload, error)
 
 	// GetSubnetDefaultPayload accepts an ip address string and checks if payloads.subnet_default_payloads table
 	// contains a payload_id for the corresponding cidr
@@ -42,10 +42,13 @@ type DB interface {
 	GetAvailablePayloads(ctx context.Context) []string
 
 	// AddNodePayload adds a NodePayloadDb entry for mac_address
-	AddNodePayload(ctx context.Context, config *NodePayloadDb) error
+	AddNodePayload(ctx context.Context, config *NodePayloadDb) ([]*NodePayload, error)
 
 	// UpdateNodePayload updates the PayloadId for mac_address.
-	UpdateNodePayload(ctx context.Context, config *NodePayloadDb) (*NodePayloadDb, error)
+	UpdateNodePayload(ctx context.Context, config *NodePayloadDb) ([]*NodePayload, error)
+
+	// DeleteNodePayload deletes the PayloadId for mac_address/payload tuple.
+	DeleteNodePayload(ctx context.Context, config *NodePayloadDb) ([]*NodePayload, error)
 
 	// GetPayload returns a payload for a node.
 	GetPayloadParameters(ctx context.Context, payloadId string) (interface{}, error)

--- a/pkg/postgres/postgres.go
+++ b/pkg/postgres/postgres.go
@@ -106,7 +106,7 @@ func (db *DB) GetNodePayloads(ctx context.Context, macAddress string) ([]*payloa
       payloads.payload_directory
     FROM "node_payloads"
     JOIN payloads on (node_payloads.payload_id = payloads.payload_id)
-    WHERE mac_address = '%s'
+    WHERE mac_address like '%s'
   `, macAddress) // #nosec G201
 
 	np_rows, err := db.conn(ctx).Query(ctx, np_sql)
@@ -275,7 +275,7 @@ func (db *DB) DeleteNodePayload(ctx context.Context, config *payloads.NodePayloa
 	dp_sql := fmt.Sprintf(`
 		DELETE from node_payloads
 		WHERE
-		    mac_address = '%s'
+		    mac_address like '%s'
         AND
         payload_id = '%s'
     RETURNING (

--- a/pkg/postgres/postgres.go
+++ b/pkg/postgres/postgres.go
@@ -95,39 +95,42 @@ func (ic *ipxeDbConfig) dto() *ipxe.IpxeDbConfig {
 	}
 }
 
-// GetPayload returns a Payload.
-// TODO: Convert to return a list of all payloads for a mac
-// TODO: In image always take index 0 of list
-func (db *DB) GetNodePayload(ctx context.Context, macAddress string) (*payloads.NodePayload, error) {
-	var np []nodePayload
+// GetNodePayloads reads all payloads for mac_address and returns them as a list.
+func (db *DB) GetNodePayloads(ctx context.Context, macAddress string) ([]*payloads.NodePayload, error) {
+	var np []*payloads.NodePayload
+
 	np_sql := fmt.Sprintf(`
-			SELECT
-				node_payloads.payload_id,
-				payloads.payload_directory,
-				node_payloads.mac_address
-			FROM "node_payloads"
-			JOIN payloads on (node_payloads.payload_id = payloads.payload_id)
-			WHERE mac_address like '%s' LIMIT 1
-	`, macAddress) // #nosec G201
+    SELECT
+      node_payloads.mac_address,
+      node_payloads.payload_id,
+      payloads.payload_directory
+    FROM "node_payloads"
+    JOIN payloads on (node_payloads.payload_id = payloads.payload_id)
+    WHERE mac_address = '%s'
+  `, macAddress) // #nosec G201
+
 	np_rows, err := db.conn(ctx).Query(ctx, np_sql)
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return nil, err
 	}
-	if err == nil {
-		np, err = pgx.CollectRows(np_rows, pgx.RowToStructByPos[nodePayload])
-	}
 	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, nil
-	}
-	if err != nil {
 		log.Printf("cannot get node_payload from database: %v\n", err)
 		return nil, errors.New("cannot get node_payload from database")
 	}
-	if len(np) == 0 {
-		return nil, nil
+	if err == nil {
+		defer np_rows.Close()
+		for np_rows.Next() {
+			var p nodePayload
+			err = np_rows.Scan(&p.MacAddress, &p.PayloadId, &p.PayloadDirectory)
+			if err != nil {
+				log.Printf("Error - GetNodePayloads - %v", err)
+			}
+			np = append(np, p.dto())
+		}
+		return np, nil
 	}
 
-	return np[0].dto(), nil
+	return nil, nil
 }
 
 // GetSubnetDefaultPayload accepts an ip address string and checks if payloads.subnet_default_payloads table
@@ -164,7 +167,7 @@ func (db *DB) GetSubnetDefaultPayload(ctx context.Context, ipAddress string) (*p
 	return sdp[0].dto(), nil
 }
 
-func (db *DB) AddNodePayload(ctx context.Context, nodePayloadDb *payloads.NodePayloadDb) error {
+func (db *DB) AddNodePayload(ctx context.Context, nodePayloadDb *payloads.NodePayloadDb) ([]*payloads.NodePayload, error) {
 	const npd_sql = `
     INSERT INTO node_payloads (
       payload_id,
@@ -180,17 +183,22 @@ func (db *DB) AddNodePayload(ctx context.Context, nodePayloadDb *payloads.NodePa
 		nodePayloadDb.MacAddress,
 	); {
 	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
-		return err
+		return nil, err
 	case err != nil:
 		if sqlErr := db.pgErrorCode(err); sqlErr != nil {
 			if sqlErr.Error() == "23505" {
-				return fmt.Errorf("node_payloads entry already exists for macAddress: %s - payloadId: %s", nodePayloadDb.MacAddress, nodePayloadDb.PayloadId)
+				return nil, fmt.Errorf("node_payloads entry already exists for macAddress: %s - payloadId: %s", nodePayloadDb.MacAddress, nodePayloadDb.PayloadId)
 			}
 		}
-		return err
+		return nil, err
+	default:
+		// Query remaining payloads for node to return
+		np, err := db.GetNodePayloads(ctx, nodePayloadDb.MacAddress)
+		if err != nil {
+			return nil, err
+		}
+		return np, nil
 	}
-
-	return nil
 }
 
 // GetAvailablePayloads returns a list of available payloads
@@ -223,8 +231,7 @@ func (db *DB) GetAvailablePayloads(ctx context.Context) []string {
 }
 
 // UpdateNodePayload updates the PayloadId for mac_address.
-func (db *DB) UpdateNodePayload(ctx context.Context, config *payloads.NodePayloadDb) (*payloads.NodePayloadDb, error) {
-	var npd *payloads.NodePayloadDb
+func (db *DB) UpdateNodePayload(ctx context.Context, config *payloads.NodePayloadDb) ([]*payloads.NodePayload, error) {
 	log.Printf("UpdateNodePayload: %v\n", *config)
 	const npd_sql = `
     UPDATE node_payloads
@@ -252,12 +259,48 @@ func (db *DB) UpdateNodePayload(ctx context.Context, config *payloads.NodePayloa
 		log.Printf("UpdateNodePayload: mac_address doesn't exist: %v\n", config)
 		return nil, fmt.Errorf(`mac_address not in database: %v`, *config)
 	default:
-		npd = &payloads.NodePayloadDb{
-			PayloadId:  config.PayloadId,
-			MacAddress: config.MacAddress,
+		// Query assigned payloads for node to return
+		np, err := db.GetNodePayloads(ctx, config.MacAddress)
+		if err != nil {
+			return nil, err
 		}
+		return np, nil
 	}
-	return npd, nil
+}
+
+// DeleteNodePayload deletes the PayloadId for mac_address.
+func (db *DB) DeleteNodePayload(ctx context.Context, config *payloads.NodePayloadDb) ([]*payloads.NodePayload, error) {
+	log.Printf("DeleteNodePayload: %v\n", config)
+	var npd *payloads.NodePayloadDb
+	dp_sql := fmt.Sprintf(`
+		DELETE from node_payloads
+		WHERE
+		    mac_address = '%s'
+        AND
+        payload_id = '%s'
+    RETURNING (
+        payload_id,
+        mac_address
+    )
+	`, config.MacAddress, config.PayloadId) // #nosec G201
+	dp_row := db.conn(ctx).QueryRow(ctx, dp_sql)
+	switch err := dp_row.Scan(&npd); {
+	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+		return nil, err
+	case err != nil:
+		if sqlErr := db.pgErrorCode(err); sqlErr != nil {
+			return nil, sqlErr
+		}
+		log.Printf("cannot delete node payload: %v\n", err)
+		return nil, fmt.Errorf(`node payload entry not in database: %v`, config)
+	default:
+		// Query remaining payloads for node to return
+		np, err := db.GetNodePayloads(ctx, config.MacAddress)
+		if err != nil {
+			return nil, err
+		}
+		return np, nil
+	}
 }
 
 // GetPayloadParameters returns an interface{} for a payloadId.
@@ -633,16 +676,16 @@ func (db *DB) pgErrorCode(err error) error {
 func (db *DB) UpdateNodeStats(ctx context.Context, n *nodes.Node) (*nodes.Node, error) {
 	const npd_sql = `
     INSERT INTO node_heartbeat (
-		mac_address, 
-		hostname, 
+		mac_address,
+		hostname,
 		ip_address
-	) 
+	)
 	VALUES (
 		$1,
 		$2,
 		$3
 	)
-	ON CONFLICT (mac_address) 
+	ON CONFLICT (mac_address)
 	DO UPDATE set mac_address = $1, hostname = $2, ip_address = $3, last_seen=now();
 	`
 	switch _, err := db.conn(ctx).Exec(ctx, npd_sql,


### PR DESCRIPTION
https://github.com/coreweave/kubernetes-node/issues/358

* Updated `pkg/api/http.go` `handlePutNodePayload` to better mirror v1 API syntax and support update/create operations based on passed params and returning list of assigned payloads
* Added `pkg/api/http.go` `handleDeleteNodePayload` and corresponding functions to allow for node_payload delete operations based on `macAddress`/`payloadId` tuples and returning list of assigned payloads
* Updated `pkg/postgres/postgres.go` `GetNodePayload` => `GetNodePayloads`
  * Configured to return list of rows based on `macAddress`
  * Reused within other functions to reduce duplication
* Updated `pkg/payloads` to standardize function outputs to `[]*NodePayload`
* Updated `README.md` to include `api/v2/payload` examples for delete and put operations 